### PR TITLE
restrict the efficiency map

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,8 @@
 *.exe
 *.out
 *.app
+
+# build files
+/build
+/.vscode
+/examples

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-# August 3 July 
+# August 3rd
 # Chen Gaoyu, chengaoyu2013@gmail.com
 # CMAKE compiling the BBSLMIRP reconstruction software
 
@@ -10,9 +10,15 @@ cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
 
 # --------
 # Set the build type
+set( CMAKE_BUILD_TYPE "Debug -O0 -Wall -g -ggdb" )
 set( CMAKE_BUILD_TYPE "Release" CACHE STRING
     "Choose the type of build, options are: Debug Release"   
 )
+# set(CMAKE_BUILD_TYPE "Debug")
+# set(CMAKE_CXX_FLAGS_DEBUG "$ENV{CXXFLAGS} -O0 -Wall -g -ggdb")
+# set(CMAKE_CXX_FLAGS_RELEASE "ENV{CXXFLAGS} -O3 -Wall")
+
+
 
 #---------
 # Defining the project

--- a/include/Algorithm/ring_mapper.h
+++ b/include/Algorithm/ring_mapper.h
@@ -18,13 +18,14 @@ public:
     RingMapper(const PETScanner& pet, const Projector& projector);
     virtual ~RingMapper();
 
-    virtual void  ComputeMap(Grid3D& map);
-
+    virtual void ComputeMap(Grid3D& map);
+    virtual void CutMap(Grid3D& map);
     virtual const PETScanner& get_pet(){return *pet;}
     virtual const Projector& get_projector(){return *projector;}
     //virtual Grid3D& get_map(){return *map;}
     // enumerate all the block pairs to compute the Map.
     virtual void Enumerate(Grid3D &map);
+
 
 private:
     const PETScanner*     pet;

--- a/include/FileIO/filestruct.h
+++ b/include/FileIO/filestruct.h
@@ -30,6 +30,7 @@ public:
     virtual void SavePoint(std::ofstream& outStream,const Point3D& pt)const;
     // image file control
     virtual bool ReadImage(const std::string& image_name, Grid3D& image)const;
+    virtual bool ReadImageBin(const std::string& image_name, Grid3D& image)const;
     virtual bool SaveImage(const std::string& image_name, const Grid3D& image)const;
     virtual bool SaveImageBin(const std::string image_name, const Grid3D& image)const;
     // data file control(original event file, translated event file)

--- a/include/Geometry/grid.h
+++ b/include/Geometry/grid.h
@@ -21,7 +21,7 @@ class Grid3D{
 public:
     Grid3D();
     virtual ~Grid3D();
-    virtual bool Initialize(const Block &);
+    virtual bool Initialize(const ObliqueBlock &);
 
     virtual void SetBlockGrid(const MeshIndex& block_grid);
 
@@ -32,7 +32,7 @@ public:
     virtual float get_mesh(int mi) const;
 
     //virtual void set_block(const VerticalBlock&);
-    virtual const Block& get_block() const;
+    virtual const ObliqueBlock& get_block() const;
     //sum the GDvalue in the grid.
     virtual float Sum() const;
     // compare the  blockgrid of two Grid3D object.
@@ -67,7 +67,7 @@ public:
 
 
 private:
-    Block block_origin;
+    ObliqueBlock block_origin;
     //the value in each mesh
     std::vector<std::vector<std::vector<float> > > mesh_value;
 };

--- a/include/ImageProcessing/filter.h
+++ b/include/ImageProcessing/filter.h
@@ -14,7 +14,7 @@ class Filter{
 public:
     Filter();
     virtual ~Filter();
-    virtual Grid3D Kaiser(const Block& bk, float alpha,int order,float radius);
+    virtual Grid3D Kaiser(const ObliqueBlock& bk, float alpha,int order,float radius);
 private:
 };
 

--- a/include/PETSystem/map_task.h
+++ b/include/PETSystem/map_task.h
@@ -21,6 +21,7 @@ public:
     virtual const GridSize& get_grid()const {return *grid;}
     virtual const Point3D& get_map_size()const{return *map_size;}
     virtual const std::string& get_map_name()const{return map_name;}
+    
 private:
     std::string projector_type;
     GridSize* grid;

--- a/include/PETSystem/petscanner.h
+++ b/include/PETSystem/petscanner.h
@@ -20,16 +20,18 @@ class Patch;
 class PETScanner
 {
 public:
-    virtual ~PETScanner(){}
-    // Initialize the scanner with a configure file.
-    virtual  void Initialize(const std::string& scanner_file) = 0;
-    // Get the number of blocks in the PET scanner.
-    virtual  int get_num_blocks() const = 0;
-    // Get the block in the block list by index.
-    virtual int  LocateBlock(const Point3D& pt) const = 0;
-    virtual const Block& get_block(int block_index) const = 0;
-    virtual const Patch& get_patch(int patch_index) const = 0;
-    virtual void DescribeSelf() const = 0;
+  virtual ~PETScanner() {}
+  // Initialize the scanner with a configure file.
+  virtual void Initialize(const std::string &scanner_file) = 0;
+  // Get the number of blocks in the PET scanner.
+  virtual int get_num_blocks() const = 0;
+  virtual float get_inner_radius() const = 0;
+  virtual float get_outer_radius() const = 0;
+  // Get the block in the block list by index.
+  virtual int LocateBlock(const Point3D &pt) const = 0;
+  virtual const Block &get_block(int block_index) const = 0;
+  virtual const Patch &get_patch(int patch_index) const = 0;
+  virtual void DescribeSelf() const = 0;
 };
-}
+} // namespace BBSLMIRP
 #endif //PET_H

--- a/main.cc
+++ b/main.cc
@@ -5,7 +5,7 @@
 */
 
 #include<iostream>
-#include "yaml-cpp/yaml.h"
+// #include "yaml-cpp/yaml.h"
 
 #include "PETSystem/petapplication.h"
 
@@ -25,11 +25,12 @@ int main(int argc, char** argv){
 
     // the todo task file
     std::string task_file = argv[2];
-
+    
     // create an application for the task and initialize it with two files.
     PETApplication app(pet_configure_file, task_file);
 
     // execute the task.
     app.Run();
+    // getchar();
     return 1;
 }

--- a/src/Algorithm/mlem.cc
+++ b/src/Algorithm/mlem.cc
@@ -11,7 +11,7 @@
 #include "projector.h"
 #include "datastruct.h"
 #include "filter.h"
-#include "./Geometry/block.h"
+#include "./Geometry/obliqueblock.h"
 namespace BBSLMIRP {
 
 MLEM::MLEM(){
@@ -89,7 +89,7 @@ void MLEM::Reconstruct(){
 
         if ((iter ) % this->output_interval == 0)
         {
-            fc.SaveImageBin(out_image_name +"_"+ std::to_string(iter) + "bin.rec", image_next);
+            fc.SaveImageBin(out_image_name +"_"+ std::to_string(iter) + ".img", image_next);
         }
     }
 
@@ -165,7 +165,7 @@ float MLEM::EM_Projection(Grid3D &ImgNow, Grid3D &ImgNext, LMEvent &lmevt) const
 void MLEM::ABF(Grid3D &image) const{
     Grid3D abf;
     Filter ft;
-    Block bok;
+    ObliqueBlock bok;
     GridSize gs1(8, 8, 8);
     bok.set_num_grid(gs1);
     abf = ft.Kaiser(bok, 10.4, 2, 2);

--- a/src/Algorithm/siddon_projector.cc
+++ b/src/Algorithm/siddon_projector.cc
@@ -79,6 +79,8 @@ void SiddonProjector::MappingLine(Ray &ray, Grid3D& map) const{
     const Block& box = map.get_block();
     //Ray& ray = Ray.get_ray();
     float LOR_length = ray.get_length();
+    // debug
+    // std::cout<<"mapping lines"<<std::endl;
     if(this->IsThroughImage(box,ray)){
         RayCast raycast;
         this->CastRay(box,ray,raycast);

--- a/src/FileIO/filestruct.cc
+++ b/src/FileIO/filestruct.cc
@@ -47,6 +47,31 @@ bool FileController::ReadImage(const std::string &image_name, Grid3D &image) con
     }
     return true;
 }
+
+bool FileController::ReadImageBin(const std::string &image_name, Grid3D &image) const{
+    std::ifstream infile(image_name, std::ios_base::in);
+    if(! infile.good()){
+        std::cerr<<"ReadImg(): no file "<<image_name <<"!"<<std::endl;
+        std::exit(-1);
+    }
+    size_t nX = image.get_block().get_num_grid().get_num_x();
+    size_t nY = image.get_block().get_num_grid().get_num_y();
+    size_t nZ = image.get_block().get_num_grid().get_num_z();
+    for (size_t k=0; k<nZ;k++){
+        for(size_t j=0; j<nY; j++){
+            for(size_t i=0; i<nX; i++){
+                //define a mesh index.
+                MeshIndex mi(i,j,k);
+                float value;
+                //read the value of the image voxels.
+                infile.read((char*)&value,sizeof(float));
+                image.set_mesh(mi,value);
+            }
+        }
+    }
+    return true;
+}
+
 bool FileController::SaveImage(const std::string &image_name, const Grid3D &image) const{
     std::ofstream outfile(image_name, std::ios_base::out);
     if(! outfile.good()){

--- a/src/Geometry/grid.cc
+++ b/src/Geometry/grid.cc
@@ -17,7 +17,7 @@ Grid3D::~Grid3D(){
 
 }
 
-bool Grid3D::Initialize(const Block& block){
+bool Grid3D::Initialize(const ObliqueBlock& block){
     this->block_origin = block;
     //this->block_origin.Initialize(block.get_num_grid(),block.get_geometry_size(),block.get_center());
     GridSize grid_size = block_origin.get_num_grid();
@@ -84,7 +84,7 @@ bool Grid3D::SizeCheck(const Grid3D& gd) const{
         return false;
 }
 
-const Block &Grid3D::get_block() const{
+const ObliqueBlock &Grid3D::get_block() const{
     return block_origin;
 }
 
@@ -209,8 +209,8 @@ void Grid3D::Conv3(const Grid3D &filter){
     GridSize filter_grid = filter.get_block().get_num_grid();
     GridSize image_grid = this->get_block().get_num_grid();
     GridSize filtered_grid = filter_grid+image_grid;
-    Block bok;
-    bok.Initialize(filtered_grid,Point3D(),Point3D());
+    ObliqueBlock bok;
+    bok.Initialize(filtered_grid,Point3D(),Point3D(), 0, 0);
     Grid3D filtered;
     filtered.Initialize(bok);
     //filtered.SetBlockGrid(filtered_grid);

--- a/src/Geometry/raycast.cc
+++ b/src/Geometry/raycast.cc
@@ -8,6 +8,8 @@
 
 #include "obliqueblock.h"
 #include "ray.h"
+
+#include <limits>
 namespace BBSLMIRP {
 
 /* class---RayCast
@@ -81,6 +83,9 @@ int RayCast::SetupRayCastComponent(const Block& imgbox, const Ray& ray, int comp
         deltaT[comp] = v_res / r_pdir;
         deltaBuf[comp] = 1;
         inBuf[comp] = v_count - pos;
+        
+        //debug
+        // std::cout<<"r_pdir > 0"<<std::endl;
 
     } else if (r_pdir < 0.0) {
 
@@ -95,6 +100,8 @@ int RayCast::SetupRayCastComponent(const Block& imgbox, const Ray& ray, int comp
         deltaT[comp] = -v_res / r_pdir;
         deltaBuf[comp] = -1;
         inBuf[comp] = pos + 1;
+        // debug
+        // std::cout<<"r_pdir < 0"<<std::endl;
 
     } else {
 
@@ -103,8 +110,11 @@ int RayCast::SetupRayCastComponent(const Block& imgbox, const Ray& ray, int comp
 //        deltaT.setp(HUGE,comp);
 //        deltaBuf.setn(0,comp);
 //        inBuf.setn(1,comp);
-        nextT[comp] = HUGE;
-        deltaT[comp] = HUGE;
+        // debug
+        // std::cout<<"r_pdir = 0"<<std::endl;
+
+        nextT[comp] = std::numeric_limits<float>::max();
+        deltaT[comp] = std::numeric_limits<float>::max();
         deltaBuf[comp] = 0;
         inBuf[comp] = 1;
     }

--- a/src/ImageProcessing/filter.cc
+++ b/src/ImageProcessing/filter.cc
@@ -5,7 +5,6 @@
 */
 
 #include "filter.h"
-
 namespace BBSLMIRP {
 Filter::Filter(){
 
@@ -15,7 +14,7 @@ Filter::~Filter(){
 
 }
 
-Grid3D Filter::Kaiser(const Block& bk, float alpha, int order, float radius){
+Grid3D Filter::Kaiser(const ObliqueBlock& bk, float alpha, int order, float radius){
     Grid3D ft;
     //ft.SetBlockGrid(bk.get_num_grid());
     ft.Initialize(bk);

--- a/src/PETSystem/map_task.cc
+++ b/src/PETSystem/map_task.cc
@@ -63,14 +63,18 @@ void MapTask::Run(const PETFactory& factory, const PETScanner& pet)const {
             projector = new SiddonProjector();
     }
     Mapper* mapper = factory.MakeMapper(pet,*projector);
-
-    Block bk;
-    bk.Initialize(this->get_grid(),this->get_map_size(),Point3D(0,0,0));
+    
+    ObliqueBlock bk;
+    bk.Initialize(this->get_grid(),this->get_map_size(),Point3D(0,0,0), 0, 0);
     Grid3D map;
     map.Initialize(bk);
     FileController fc;
     //compute the normaliztion map
     mapper->ComputeMap(map);
-    fc.SaveImage(this->get_map_name(),map);
+    // debug
+    // std::cout<<"pass here!"<<std::endl;
+
+    fc.SaveImageBin(this->get_map_name(),map);
 }
+
 }

--- a/src/PETSystem/reconstruction_task.cc
+++ b/src/PETSystem/reconstruction_task.cc
@@ -99,14 +99,14 @@ void ReconstructionTask::Run(const PETFactory&factory, const PETScanner& pet) co
     Translator* pet_translator = factory.MakeTranslator(pet);
     pet_translator->TranslateEvents(this->input_file,this->output_image_name);
 
-    Block bk;
-    bk.Initialize(this->get_grid(),this->get_image_size(),Point3D(0,0,0));
+    ObliqueBlock bk;
+    bk.Initialize(this->get_grid(),this->get_image_size(),Point3D(0,0,0),0,0);
 
     //read the normalization map
     Grid3D map;
     map.Initialize(bk);
     FileController fc;
-    fc.ReadImage(this->map_name,map);
+    fc.ReadImageBin(this->map_name,map);
 
     Projector *projector = NULL;
     if (this->projector_type == "siddon"){


### PR DESCRIPTION
Set the FOV of a cylinder PET scanner to be 0.95*inner_radius. The factor (0.95) is used to prevent the max values within the region of crystals caused by the mismatch between map computing and reconstruction.