### PR TITLE
Dev cgy

### DIFF
--- a/include/Geometry/grid.h
+++ b/include/Geometry/grid.h
@@ -12,7 +12,7 @@
 #include"obliqueblock.h"
 namespace BBSLMIRP{
 
-const float kEps = 0.00000001;
+const float kEps = 0.0000001;
 
 class GridSize;
 typedef GridSize MeshIndex;

--- a/include/PETSystem/petscanner.h
+++ b/include/PETSystem/petscanner.h
@@ -27,6 +27,7 @@ public:
   virtual int get_num_blocks() const = 0;
   virtual float get_inner_radius() const = 0;
   virtual float get_outer_radius() const = 0;
+  virtual float get_fov_ratio() const = 0;
   // Get the block in the block list by index.
   virtual int LocateBlock(const Point3D &pt) const = 0;
   virtual const Block &get_block(int block_index) const = 0;

--- a/include/PETSystem/ringpet.h
+++ b/include/PETSystem/ringpet.h
@@ -30,6 +30,7 @@ public:
     // setter and getter
     virtual void set_inner_radius(float radius) { this->inner_radius = radius; }
     virtual void set_outer_radius(float radius) { this->outer_radius = radius; }
+    virtual void set_fov_ratio(float fov_ratio){this->fov_ratio = fov_ratio;}
     virtual void set_height(float height) { this->height = height; }
     virtual void set_ring_gap(float ring_gap) { this->ring_gap = ring_gap; }
     virtual void set_num_rings(int nRings) { this->num_rings = nRings; }
@@ -37,6 +38,7 @@ public:
 
     virtual float get_inner_radius() const { return this->inner_radius; }
     virtual float get_outer_radius() const { return this->outer_radius; }
+    virtual float get_fov_ratio()const {return this->fov_ratio;}
     virtual float get_height() const { return this->height; }
     virtual float get_ring_gap() const { return this->ring_gap; }
     virtual int   get_num_rings() const { return this->num_rings; }
@@ -48,6 +50,7 @@ public:
   private:
     float inner_radius;
     float outer_radius;
+    float fov_ratio;
     float height;
     float ring_gap;
     int   num_rings;

--- a/include/PETSystem/spherepet.h
+++ b/include/PETSystem/spherepet.h
@@ -28,9 +28,10 @@ public:
     // setter and getter
     virtual void set_inner_radius(float radius) { this->inner_radius = radius; }
     virtual void set_outer_radius(float radius) { this->outer_radius = radius; }
+    virtual void set_fov_ratio(float fov_ratio){this->fov_ratio = fov_ratio;}
     virtual float get_inner_radius() const { return this->inner_radius; }
     virtual float get_outer_radius() const { return this->outer_radius; }
-
+    virtual float get_fov_ratio()const {return this->fov_ratio;}
     virtual void set_mesh_size(const Point3D& mesh_size){this->mesh_size = mesh_size;}
     virtual const Point3D& get_mesh_size()const{
         return mesh_size;
@@ -41,6 +42,7 @@ public:
 private:
     float inner_radius;
     float outer_radius;
+    float fov_ratio;
     Point3D mesh_size;
     std::vector<ObliqueBlock> block_list;
     std::vector<Patch> patch_list;

--- a/src/Algorithm/mlem.cc
+++ b/src/Algorithm/mlem.cc
@@ -63,8 +63,8 @@ void MLEM::Reconstruct(){
     {
         image_now = image_next;
         //'image_next' will aaccumulate the backprojection of the reciprocal line integrals of 'this->img'.
-        image_next.SetAllMeshes(0);
-        this->EM(image_now,image_next, 0, this->in_file_name);
+        image_next.SetAllMeshes(0.0);
+        this->EM(image_now,image_next, 0.0, this->in_file_name);
 
 //        float gavg = image_now.Sum()/ image_now.get_block().get_num_grid().GetTotalNumOfMeshes();
 //        Grid3D temp1 = image_now * image_now;
@@ -166,7 +166,7 @@ void MLEM::ABF(Grid3D &image) const{
     Grid3D abf;
     Filter ft;
     ObliqueBlock bok;
-    GridSize gs1(8, 8, 8);
+    GridSize gs1(4, 4, 4);
     bok.set_num_grid(gs1);
     abf = ft.Kaiser(bok, 10.4, 2, 2);
     image.Conv3(abf);

--- a/src/Algorithm/ring_mapper.cc
+++ b/src/Algorithm/ring_mapper.cc
@@ -84,7 +84,7 @@ void RingMapper::CutMap(Grid3D& map){
         mpt.set_pz(center.get_pz());
         map.get_block().LocatePoint(iMesh,mpt);
         float dis = (mpt-center).GetNorm2();
-        if (dis > 0.95*innerR){
+        if (dis > pet->get_fov_ratio()*innerR){
             map.set_mesh(iMesh, 0.0);
         }
     }

--- a/src/Geometry/grid.cc
+++ b/src/Geometry/grid.cc
@@ -314,7 +314,7 @@ Grid3D Grid3D::operator/(const Grid3D& gd){
                 for(int iZ = 0; iZ < nZ;iZ++){
                     GridSize loc(iX,iY,iZ);
                     if(std::abs(gd.get_mesh(loc)) <= kEps){ // if the dividor is zero, set the result zero.
-                        divideGD.set_mesh(loc,this->get_mesh(loc));
+                        divideGD.set_mesh(loc, 0.0);
                     }
                     else{
                         float value = this->get_mesh(loc)/gd.get_mesh(loc);

--- a/src/PETSystem/ringpet.cc
+++ b/src/PETSystem/ringpet.cc
@@ -27,6 +27,7 @@ void RingPET::Initialize(const std::string& scanner_file){
     int   nBlocks, nRings;
     int   nx, ny ,nz;
     float gx, gy, gz;
+    float fov_ratio = 0.95;
     std::string key;
     while(!configure.eof()){
        configure >> key;
@@ -48,6 +49,8 @@ void RingPET::Initialize(const std::string& scanner_file){
            configure>>nx>>ny>>nz;
        else if(key =="BlockSize:")
            configure>>gx>>gy>>gz;
+       else if(key =="FovRatio:")
+           configure>>fov_ratio;
        else{
 
        }
@@ -60,6 +63,7 @@ void RingPET::Initialize(const std::string& scanner_file){
     this->set_ring_gap(gap); //important.
     this->set_num_blocks_per_ring(nBlocks);
     this->set_num_rings(nRings);
+    this->set_fov_ratio(fov_ratio);
 
     ObliqueBlock vb;
     vb.Initialize(GridSize(nx,ny,nz),Point3D(gx,gy,gz),Point3D(0,0,0),0,0);

--- a/src/PETSystem/spherepet.cc
+++ b/src/PETSystem/spherepet.cc
@@ -6,58 +6,65 @@
 #include "spherepet.h"
 #include "filestruct.h"
 #include <float.h>
-namespace BBSLMIRP {
+namespace BBSLMIRP
+{
 
-SpherePET::SpherePET(const std::string &scanner_file){
+SpherePET::SpherePET(const std::string &scanner_file)
+{
     this->Initialize(scanner_file);
 }
-SpherePET::~SpherePET(){
-
+SpherePET::~SpherePET()
+{
 }
 
-void SpherePET::DescribeSelf()const{
-
+void SpherePET::DescribeSelf() const
+{
 }
-void SpherePET::Initialize(const std::string &scanner_file){
+void SpherePET::Initialize(const std::string &scanner_file)
+{
     std::ifstream configure(scanner_file, std::ios_base::in);
     float in_radius, out_radius;
     float mx, my, mz;
     std::string patch_list_file;
-
+    float fov_ratio = 0.9;
     std::string key;
-    while(!configure.eof()){
-       configure >> key;
-       if(key == "PETScanner:")
-           configure>>key;
-       else if(key == "InnerRadius:")
-           configure>>in_radius;
-       else if(key == "OuterRadius:")
-           configure>>out_radius;
-       else if(key == "MeshSize:")
-           configure>>mx>>my>>mz;
-       else if(key == "PatchListName:")
-           configure>>patch_list_file;
-       else{
-
-       }
+    while (!configure.eof())
+    {
+        configure >> key;
+        if (key == "PETScanner:")
+            configure >> key;
+        else if (key == "InnerRadius:")
+            configure >> in_radius;
+        else if (key == "OuterRadius:")
+            configure >> out_radius;
+        else if (key == "MeshSize:")
+            configure >> mx >> my >> mz;
+        else if (key == "PatchListName:")
+            configure >> patch_list_file;
+        else if (key == "FovRatio")
+            configure >> fov_ratio;
+        else
+        {
+        }
     }
     configure.close();
 
     this->set_inner_radius(in_radius);
     this->set_outer_radius(out_radius);
-    this->set_mesh_size(Point3D(mx,my,mz));
-
+    this->set_mesh_size(Point3D(mx, my, mz));
+    this->set_fov_ratio(fov_ratio);
     this->patch_list.clear();
     this->block_list.clear();
     this->make_block_list(patch_list_file);
 }
 
 //to be enhanced to make it faster.
-int SpherePET::LocateBlock(const Point3D &pt) const{
+int SpherePET::LocateBlock(const Point3D &pt) const
+{
     // find the most posible 4 blocks that contains the point.
     // where the angle between the block center and the point is smallest.
     // cosine is the largest.
-/*    float cosine_list[4] = {FLT_MAX};
+    /*    float cosine_list[4] = {FLT_MAX};
     int index_list[4] = {block_list.size()};
     for(int iter = 0; iter < block_list.size();iter++){
         //compute the dot product of the block center with the point
@@ -92,21 +99,25 @@ int SpherePET::LocateBlock(const Point3D &pt) const{
     int block_index = -1;
     //std::cout<<patch_list.size()<<std::endl;
     //std::cout<<block_list.size()<<std::endl;
-    for (int iter = 0; iter < patch_list.size(); iter++){
-        const Patch& patch = patch_list[iter];
-        if (patch.IsInPatch(pt)){
+    for (int iter = 0; iter < patch_list.size(); iter++)
+    {
+        const Patch &patch = patch_list[iter];
+        if (patch.IsInPatch(pt))
+        {
             block_index = iter;
             break;
         }
     }
     //if block_index is out of range, return  -1;
-    return block_index < this->get_num_blocks()? block_index:-1;
+    return block_index < this->get_num_blocks() ? block_index : -1;
 }
 
-void SpherePET::make_block_list(const std::string& patch_list_file){
+void SpherePET::make_block_list(const std::string &patch_list_file)
+{
     std::ifstream infile(patch_list_file, std::ios_base::in);
-    if(! infile.good()){
-        std::cerr<<"make_block_list(): no file "<< patch_list_file <<"!"<<std::endl;
+    if (!infile.good())
+    {
+        std::cerr << "make_block_list(): no file " << patch_list_file << "!" << std::endl;
         std::exit(-1);
     }
     FileController fc;
@@ -116,13 +127,15 @@ void SpherePET::make_block_list(const std::string& patch_list_file){
     this->block_list.clear();
     int num_patches = 0;
     infile >> num_patches;
-    for(int iPatch = 0 ;iPatch<num_patches;iPatch++){
-        fc.ReadPatch(infile,patch);
+    for (int iPatch = 0; iPatch < num_patches; iPatch++)
+    {
+        fc.ReadPatch(infile, patch);
         int num_inner_edges = patch.get_inside_face().size();
         int num_outer_edges = patch.get_inside_face().size();
         //debug
         //std::cout<<num_inner_edges <<"  "<<num_outer_edges<<std::endl;
-        if(num_inner_edges == num_outer_edges && num_inner_edges>0){
+        if (num_inner_edges == num_outer_edges && num_inner_edges > 0)
+        {
             this->patch_list.push_back(patch);
             this->block_list.push_back(patch.CreateBlock(this->get_mesh_size()));
         }
@@ -132,4 +145,4 @@ void SpherePET::make_block_list(const std::string& patch_list_file){
     //std::cout<<patch_list.size();
 }
 
-}
+} // namespace BBSLMIRP


### PR DESCRIPTION
1. Fix the bug in grid divide operator.
2. Add the fov_ratio interface for RingPET. Users can control the FOV size by modify a "FovRatio" value in a scanner configure file. The value ranges from (0,1]. The image values will be set to zero if the pixel is out of the FOV.